### PR TITLE
Cleaning up config values and fixing search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Created by .ignore support plugin (hsz.mobi)
+.gitignore
+.idea/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ composer require travoltron/plaid
 In `app/config.php` add the following line to the alias array
 
 ```bash
-'Plaid' => 'Travoltron\Plaid\Plaid::class',
+'Plaid' => Travoltron\Plaid\Plaid::class,
 ```
 
 Publish configuration file

--- a/src/Plaid.php
+++ b/src/Plaid.php
@@ -92,7 +92,7 @@ class Plaid
                 'body' => [
                     'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
-                    'access_token' => $public_token,
+                    'access_token' => $plaid_token,
                 ]
             ]);
             return $request->json();
@@ -262,7 +262,7 @@ class Plaid
                 'body' => [
                     'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
-                    'access_token' => $token,
+                    'access_token' => $plaid_token,
                     'options' => [
                         'pending' => config('plaid.connect.pending'),
                         'gte' => $start,

--- a/src/Plaid.php
+++ b/src/Plaid.php
@@ -166,8 +166,8 @@ class Plaid
      */
     public static function addConnectUser($username, $password, $pin = null, $type, $webhook, $start_date = null, $end_date = null)
     {
-        $start = ($start_date?Carbon::parse($start_date)->toDateString():Carbon::now()->subDays(config('plaid.connect.start_date'))->toDateString());
-        $end = ($end_date?Carbon::parse($end_date)->toDateString():Carbon::now()->subDays(config('plaid.connect.end_date'))->toDateString());
+        $start = ($start_date ? Carbon::parse($start_date)->toDateString() : Carbon::now()->subDays(config('plaid.connect.start_date'))->toDateString());
+        $end = ($end_date ? Carbon::parse($end_date)->toDateString() : Carbon::now()->subDays(config('plaid.connect.end_date'))->toDateString());
         try {
             $request = self::client()->post('connect', [
                 'body' => [
@@ -255,8 +255,8 @@ class Plaid
 
     public static function getConnectData($plaid_token, $start_date = null, $end_date = null)
     {
-        $start = ($start_date?Carbon::parse($start_date)->toDateString():Carbon::now()->subDays(config('plaid.connect.start_date'))->toDateString());
-        $end = ($end_date?Carbon::parse($end_date)->toDateString():Carbon::now()->subDays(config('plaid.connect.end_date'))->toDateString());
+        $start = ($start_date ? Carbon::parse($start_date)->toDateString() : Carbon::now()->subDays(config('plaid.connect.start_date'))->toDateString());
+        $end = ($end_date ? Carbon::parse($end_date)->toDateString() : Carbon::now()->subDays(config('plaid.connect.end_date'))->toDateString());
         try {
             $request = self::client()->post('connect/get', [
                 'body' => [
@@ -328,8 +328,8 @@ class Plaid
      */
     public static function getConnectTransactions($plaid_token, $start_date = null, $end_date = null)
     {
-        $start = ($start_date?Carbon::parse($start_date)->toDateString():Carbon::now()->subDays(config('plaid.connect.start_date'))->toDateString());
-        $end = ($end_date?Carbon::parse($end_date)->toDateString():Carbon::now()->subDays(config('plaid.connect.end_date'))->toDateString());
+        $start = ($start_date ? Carbon::parse($start_date)->toDateString() : Carbon::now()->subDays(config('plaid.connect.start_date'))->toDateString());
+        $end = ($end_date ? Carbon::parse($end_date)->toDateString() : Carbon::now()->subDays(config('plaid.connect.end_date'))->toDateString());
         try {
             $request = self::client()->post('connect/get', [
                 'body' => [
@@ -854,12 +854,17 @@ class Plaid
     public static function search($query, $product = null, $institution_id = null)
     {
         try {
+            $queryParams = [];
+            if($institution_id !== null) {
+                $queryParams['id'] = $institution_id;
+            } else {
+                $queryParams['q'] = $query;
+                if($product !== null) {
+                    $queryParams['p'] = $product;
+                }
+            }
             $request = self::client()->get('institutions/search', [
-                'query' => [
-                    'q' => $query,
-                    'p' => $product,
-                    'id' => $institution_id
-                ]
+                'query' => $queryParams
             ]);
             return $request->json();
         } catch (RequestException $e) {

--- a/src/Plaid.php
+++ b/src/Plaid.php
@@ -33,7 +33,7 @@ class Plaid
         try {
             $request = self::client()->post('auth', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -63,7 +63,7 @@ class Plaid
         try {
             $request = self::client()->post('auth/step', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'mfa' => $mfa,
                     'access_token' => $plaid_token,
@@ -115,7 +115,7 @@ class Plaid
         try {
             $request = self::client()->patch('auth', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -140,7 +140,7 @@ class Plaid
         try {
             $request = self::client()->delete('auth', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'access_token' => $plaid_token,
                 ]
@@ -171,7 +171,7 @@ class Plaid
         try {
             $request = self::client()->post('connect', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -206,7 +206,7 @@ class Plaid
         try {
             $request = self::client()->post('connect/step', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'mfa' => $mfa,
                     'access_token' => $plaid_token,
@@ -236,7 +236,7 @@ class Plaid
         try {
             $request = self::client()->patch('connect', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -287,7 +287,7 @@ class Plaid
         try {
             $request = self::client()->delete('connect', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'access_token' => $plaid_token,
                 ]
@@ -367,7 +367,7 @@ class Plaid
         try {
             $request = self::client()->post('info', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -398,7 +398,7 @@ class Plaid
         try {
             $request = self::client()->post('info/step', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'mfa' => $mfa,
                     'access_token' => $plaid_token,
@@ -428,7 +428,7 @@ class Plaid
         try {
             $request = self::client()->patch('info', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -456,7 +456,7 @@ class Plaid
         try {
             $request = self::client()->delete('info', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'access_token' => $plaid_token,
                 ]
@@ -507,7 +507,7 @@ class Plaid
         try {
             $request = self::client()->post('income', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -538,7 +538,7 @@ class Plaid
         try {
             $request = self::client()->post('income/step', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'mfa' => $mfa,
                     'access_token' => $plaid_token,
@@ -568,7 +568,7 @@ class Plaid
         try {
             $request = self::client()->patch('income', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -596,7 +596,7 @@ class Plaid
         try {
             $request = self::client()->delete('income', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'access_token' => $plaid_token,
                 ]
@@ -647,7 +647,7 @@ class Plaid
         try {
             $request = self::client()->post('risk', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -678,7 +678,7 @@ class Plaid
         try {
             $request = self::client()->post('risk/step', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'mfa' => $mfa,
                     'access_token' => $plaid_token,
@@ -708,7 +708,7 @@ class Plaid
         try {
             $request = self::client()->patch('risk', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'username' => $username,
                     'password' => $password,
@@ -736,7 +736,7 @@ class Plaid
         try {
             $request = self::client()->delete('risk', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'access_token' => $plaid_token,
                 ]
@@ -835,7 +835,7 @@ class Plaid
         try {
             $request = self::client()->post('institutions/longtail', [
                 'body' => [
-                    'client_id' => config('plaid.client-id'),
+                    'client_id' => config('plaid.client_id'),
                     'secret' => config('plaid.secret'),
                     'count' => $count,
                     'offset' => $offset


### PR DESCRIPTION
Just a couple of issues we ran into cleaned up:

* Config values were not consistent client_id vs client-id, I standardized on client_id as it's what is in the config file. The current workaround is to set both client_id and client-id in config

* Fixing search which previously would not return anything if you just passed a query. Now it doesn't pass the products (p) key up if it's null. The current workaround is to pass up all products.